### PR TITLE
Bump pyogero to 0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to package (e.g. v0.6.0-beta.1)
+        required: true
+        type: string
 
 permissions: {}
 
@@ -17,7 +23,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: ZIP the integration directory
         shell: bash
@@ -28,4 +34,5 @@ jobs:
       - name: Upload the ZIP file to the release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
+          tag_name: ${{ github.event.release.tag_name || inputs.tag }}
           files: ${{ github.workspace }}/custom_components/ogero/ogero.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: ZIP the integration directory
         shell: bash
@@ -24,6 +26,6 @@ jobs:
           zip ogero.zip -r ./
 
       - name: Upload the ZIP file to the release
-        uses: softprops/action-gh-release@05c4f37acfe488b4df30f47f3ceff176ae5a2e92 # v2.5.0
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           files: ${{ github.workspace }}/custom_components/ogero/ogero.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.install == 'latest'
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install colorlog pyogero==0.13.0
+          python3 -m pip install colorlog pyogero==0.14.0
           python3 -m pip install homeassistant
           python3 -m pip install pytest-homeassistant-custom-component pytest-timeout
 

--- a/custom_components/ogero/manifest.json
+++ b/custom_components/ogero/manifest.json
@@ -10,7 +10,7 @@
   "issue_tracker": "https://github.com/oraad/ha-ogero/issues",
   "quality_scale": "platinum",
   "requirements": [
-    "pyogero==0.13.0"
+    "pyogero==0.14.0"
   ],
   "version": "0.6.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 colorlog==6.10.1
 homeassistant==2026.3.2
 pip>=24.0
-pyogero==0.13.0
+pyogero==0.14.0
 pytest-homeassistant-custom-component==0.13.318
 pytest-timeout==2.4.0
 ruff==0.15.13


### PR DESCRIPTION
## Summary
- Bump **pyogero** dependency to **0.14.0** in the integration manifest, `requirements.txt`, and the Test workflow latest matrix leg.
- Cherry-pick-aligned release workflow fixes (valid `action-gh-release` pin, checkout release tag, `workflow_dispatch` for repackaging tags).

## Motivation
[pyogero 0.14.0](https://github.com/oraad/pyogero/releases/tag/v0.14.0) relaxes dependency upper bounds and targets Python 3.14+, matching our HA 2026.3.2 stack.

## Test plan
- [ ] CI: Lint, Test (pinned + latest), Validate (hassfest + HACS)
- [ ] Install integration on HA 2026.3.2 and confirm config flow + sensors load
